### PR TITLE
Unicornの設定を変更

### DIFF
--- a/config/unicorn/production.rb
+++ b/config/unicorn/production.rb
@@ -3,7 +3,7 @@ rails_root = File.expand_path('../../../', __FILE__)
 worker_processes 2
 working_directory rails_root
 
-listen "#{rails_root}/tmp/sockets/unicorn.sock"
+listen 3000
 pid "#{rails_root}/tmp/pids/unicorn.pid"
 
 stderr_path "#{rails_root}/log/unicorn_error.log"


### PR DESCRIPTION
### 概要

Unicornの設定において、unix domain socketからTCPへの変更を行います
### 目的
- nginxとappを同一サーバー上でなく、別構成にするため
  - ソケット(unicorn.sock)を共有せず、TCPで行う方向になりましたのでその対応を行います
