### PR TITLE
設定変更

### DIFF
--- a/config/deploy.rb
+++ b/config/deploy.rb
@@ -25,6 +25,7 @@ set :repo_url, 'https://github.com/ogidow/railstutorial.git'
 
 # Default value for :linked_files is []
 # set :linked_files, fetch(:linked_files, []).push('config/database.yml', 'config/secrets.yml')
+set :linked_files, %w{config/database.yml config/secrets.yml}
 
 # Default value for linked_dirs is []
 set :linked_dirs, fetch(:linked_dirs, []).push('log', 'tmp/pids', 'tmp/cache', 'tmp/sockets')

--- a/config/deploy/production.rb
+++ b/config/deploy/production.rb
@@ -19,6 +19,7 @@ server 'all',
 
 set :rails_env, 'production'
 set :branch, 'master'
+set :linked_files, %w{config/database.yml}
 
 # role-based syntax
 # ==================

--- a/config/deploy/production.rb
+++ b/config/deploy/production.rb
@@ -19,7 +19,7 @@ server 'all',
 
 set :rails_env, 'production'
 set :branch, 'master'
-set :linked_files, %w{config/database.yml}
+set :linked_files, %w{config/database.yml config/secrets.yml}
 
 # role-based syntax
 # ==================

--- a/config/deploy/production.rb
+++ b/config/deploy/production.rb
@@ -19,7 +19,6 @@ server 'all',
 
 set :rails_env, 'production'
 set :branch, 'master'
-set :linked_files, %w{config/database.yml config/secrets.yml}
 
 # role-based syntax
 # ==================


### PR DESCRIPTION
`config/database.yml`と`config/secrets.yml`をそれぞれ`shared/config/database.yml`、`sharedconfig/secrets.yml`にシンボリックリンクにします。

これによって機密情報をこのリポジトリに含めないようにすることができます
