### PR TITLE
webロールにassets:precompileが走るのでwebロールは必要だった

### DIFF
--- a/config/deploy/development.rb
+++ b/config/deploy/development.rb
@@ -9,7 +9,7 @@
 %w(app01 app02).each do |host|
   server host,
     user: 'rails',
-    roles: %w{app db},
+    roles: %w{app db web},
     ssh_options: {
       keys: %w(~/.ssh/id_ed25519),
       forward_agent: true,

--- a/config/deploy/production.rb
+++ b/config/deploy/production.rb
@@ -9,7 +9,7 @@
 %w(app01 app02).each do |host|
   server host,
     user: 'rails',
-    roles: %w{app db},
+    roles: %w{app db web},
     ssh_options: {
       keys: %w(~/.ssh/id_ed25519),
       forward_agent: true,


### PR DESCRIPTION
タイトルの通りwebロールを戻します

今後revproxyロールにassetsを置く設定にしていきます（#61）が、現時点で正常に動く設定にしておくため対応します
