### PR TITLE
UserKnownHostsFile=/dev/nullにして、known_hostsへ記録させないようにする

### DIFF
--- a/config/deploy/development.rb
+++ b/config/deploy/development.rb
@@ -14,6 +14,7 @@
       keys: %w(~/.ssh/id_ed25519),
       forward_agent: true,
       auth_methods: %w(publickey),
+      user_known_hosts_file: '/dev/null',
       proxy: Net::SSH::Proxy::Command.new('ssh -p 2222 -i ~/.ssh/id_ed25519 rails@localhost -oStrictHostKeyChecking=no -oUserKnownHostsFile=/dev/null -W %h:%p')
     }
 end
@@ -25,6 +26,7 @@ server 'revproxy_a01',
       keys: %w(~/.ssh/id_ed25519),
       forward_agent: true,
       auth_methods: %w(publickey),
+      user_known_hosts_file: '/dev/null',
       proxy: Net::SSH::Proxy::Command.new('ssh -p 2222 -i ~/.ssh/id_ed25519 revproxy@localhost -oStrictHostKeyChecking=no -oUserKnownHostsFile=/dev/null -W %h:%p')
     }
 

--- a/config/deploy/development.rb
+++ b/config/deploy/development.rb
@@ -14,7 +14,7 @@
       keys: %w(~/.ssh/id_ed25519),
       forward_agent: true,
       auth_methods: %w(publickey),
-      proxy: Net::SSH::Proxy::Command.new('ssh -oStrictHostKeyChecking=no -i ~/.ssh/id_ed25519 rails@localhost -p 2222 -W %h:%p')
+      proxy: Net::SSH::Proxy::Command.new('ssh -p 2222 -i ~/.ssh/id_ed25519 rails@localhost -oStrictHostKeyChecking=no -oUserKnownHostsFile=/dev/null -W %h:%p')
     }
 end
 
@@ -25,7 +25,7 @@ server 'revproxy_a01',
       keys: %w(~/.ssh/id_ed25519),
       forward_agent: true,
       auth_methods: %w(publickey),
-      proxy: Net::SSH::Proxy::Command.new('ssh -oStrictHostKeyChecking=no -i ~/.ssh/id_ed25519 revproxy@localhost -p 2222 -W %h:%p')
+      proxy: Net::SSH::Proxy::Command.new('ssh -p 2222 -i ~/.ssh/id_ed25519 revproxy@localhost -oStrictHostKeyChecking=no -oUserKnownHostsFile=/dev/null -W %h:%p')
     }
 
 set :rails_env, 'production'


### PR DESCRIPTION
`StrictHostKeyChecking=no`によってホストキーの照合は無視されているのですが、known_hostsへの記録は行われてしまいます。
この設定を行うことで、開発環境のホストは記録自体を行わないようにすることができます。
（インフラREADMEのSSH設定にはこれも含まれています）
