### PR TITLE
feedとユーザのmicropost一覧のページング

### DIFF
--- a/app/controllers/api/users_controller.rb
+++ b/app/controllers/api/users_controller.rb
@@ -58,7 +58,7 @@ class Api::UsersController < Api::ApplicationController
 
     render nothing: true, status: :forbidden and return unless @user.activated?
 
-    @microposts = @user.microposts.restrict request_microposts_params
+    @microposts = @user.microposts.restrict request_microposts_params.to_h.symbolize_keys
 
     render 'microposts', status: :ok
   end
@@ -66,7 +66,7 @@ class Api::UsersController < Api::ApplicationController
   def feed
     @user = current_user
     render nothing: true, status: :forbidden and return unless @user.activated?
-    @feed = @user.feed.restrict request_microposts_params
+    @feed = @user.feed.restrict request_microposts_params.to_h.symbolize_keys
 
     render 'feed', status: :ok
   end

--- a/app/controllers/api/users_controller.rb
+++ b/app/controllers/api/users_controller.rb
@@ -58,7 +58,7 @@ class Api::UsersController < Api::ApplicationController
 
     render nothing: true, status: :forbidden and return unless @user.activated?
 
-    @microposts = @user.microposts.restrict request_microposts_params.to_h.symbolize_keys
+    @microposts = @user.microposts.restrict(request_microposts_params.to_h.symbolize_keys)
 
     render 'microposts', status: :ok
   end
@@ -66,7 +66,7 @@ class Api::UsersController < Api::ApplicationController
   def feed
     @user = current_user
     render nothing: true, status: :forbidden and return unless @user.activated?
-    @feed = @user.feed.restrict request_microposts_params.to_h.symbolize_keys
+    @feed = @user.feed.restrict(request_microposts_params.to_h.symbolize_keys)
 
     render 'feed', status: :ok
   end

--- a/app/controllers/api/users_controller.rb
+++ b/app/controllers/api/users_controller.rb
@@ -58,7 +58,7 @@ class Api::UsersController < Api::ApplicationController
 
     render nothing: true, status: :forbidden and return unless @user.activated?
 
-    @microposts = @user.microposts
+    @microposts = @user.microposts.restrict request_microposts_params
 
     render 'microposts', status: :ok
   end
@@ -66,7 +66,7 @@ class Api::UsersController < Api::ApplicationController
   def feed
     @user = current_user
     render nothing: true, status: :forbidden and return unless @user.activated?
-    @feed = @user.feed
+    @feed = @user.feed.restrict request_microposts_params
 
     render 'feed', status: :ok
   end
@@ -74,6 +74,10 @@ class Api::UsersController < Api::ApplicationController
   private
     def user_params
       params.require(:user).permit(:name, :email, :password, :password_confirmation)
+    end
+
+    def request_microposts_params
+      params.fetch(:request_microposts, {}).permit(:since_id, :max_id, :count)
     end
 
     def correct_user

--- a/app/models/micropost.rb
+++ b/app/models/micropost.rb
@@ -8,7 +8,7 @@ class Micropost < ActiveRecord::Base
 
   DEFAULT_COUNT = 30 # micropost一覧はデフォルトでは30件とってくる
 
-  def self.restrict count: DEFAULT_COUNT, since_id: nil, max_id: nil
+  def self.restrict(count: DEFAULT_COUNT, since_id: nil, max_id: nil)
     result = self # これにメソッドチェーンでクエリをつけていく
 
     unless since_id.nil?

--- a/app/models/micropost.rb
+++ b/app/models/micropost.rb
@@ -6,6 +6,22 @@ class Micropost < ActiveRecord::Base
   validates :content, presence: true, length: {maximum: 140}
   validate :picture_size
 
+  DEFAULT_COUNT = 30 # micropost一覧はデフォルトでは30件とってくる
+
+  def self.restrict count: DEFAULT_COUNT, since_id: nil, max_id: nil
+    result = self # これにメソッドチェーンでクエリをつけていく
+
+    unless since_id.nil?
+      result = result.where(Micropost.arel_table[:id].gt since_id)
+    end
+
+    unless max_id.nil?
+      result = result.where(Micropost.arel_table[:id].lteq max_id)
+    end
+
+    result.limit count
+  end
+
   private
 
   def picture_size

--- a/app/models/micropost.rb
+++ b/app/models/micropost.rb
@@ -12,11 +12,11 @@ class Micropost < ActiveRecord::Base
     result = self # これにメソッドチェーンでクエリをつけていく
 
     unless since_id.nil?
-      result = result.where(Micropost.arel_table[:id].gt since_id)
+      result = result.where("id > ?", since_id)
     end
 
     unless max_id.nil?
-      result = result.where(Micropost.arel_table[:id].lteq max_id)
+      result = result.where("id <= ?", max_id)
     end
 
     result.limit count

--- a/test/fixtures/microposts.yml
+++ b/test/fixtures/microposts.yml
@@ -1,39 +1,47 @@
 orange:
+  id: 1
   content: "I just ate an orange!"
   created_at: <%= 10.minutes.ago.to_datetime %>
   user: michael
 
 tau_manifesto:
+  id: 2
   content: "Check out the @tauday site by p mhartl: http://tauday.com"
   created_at: <%= 3.years.ago.to_datetime %>
   user: michael
 
 cat_video:
+  id: 3
   content: "Sad cats are sad: http://youtu.be/PKffm2ul4dk"
   created_at: <%= 2.hours.ago.to_datetime %>
   user: michael
 
 most_recent:
+  id: 4
   content: "Writing a short test"
   created_at: <%= Time.zone.now.to_datetime %>
   user: michael
 
 ants:
+  id: 5
   content: "Oh, is that what you want? Because that's how you get ants!"
   created_at: <%= 2.years.ago.to_datetime %>
   user: archer
 
 zone:
+  id: 6
   content: "Danger zone!"
   created_at: <%= 3.days.ago.to_datetime %>
   user: archer
 
 tone:
+  id: 7
   content: "I'm sorry. Your words made sense, but your sarcastic tone did not"
   created_at: <%= 10.minutes.ago.to_datetime %>
   user: lana
 
 van:
+  id: 8
   content: "Dude, this van's like, rolling proable cause."
   created_at: <%= 4.hours.ago.to_datetime %>
   user: lana
@@ -41,6 +49,7 @@ van:
 
 <% 30.times do |n| %>
 micropost_<%= n %>:
+  id: <%= n + 9 %>
   content: <%= Faker::Lorem.sentence(5) %>
   created_at: <%= 42.days.ago.to_datetime %>
   user: michael

--- a/test/integration/api/feed_test.rb
+++ b/test/integration/api/feed_test.rb
@@ -42,17 +42,41 @@ class Api::FeedTest< ActionDispatch::IntegrationTest
     assert_equal 10, response_json[:feed].length
   end
 
-  test "feed取得(idが)" do
-    get api_feed_path, {request_microposts: {count: 35}}, @headers
+  test "feed取得(idが10より後のmicropostのみ)" do
+    # since_idを指定
+    get api_feed_path, {request_microposts: {since_id: 10}}, @headers
     assert_response :success
 
-    # 50件取得する
-    assert_equal 35, response_json[:feed].length
-
-    # 全micropostのidが100超であることを検証
+    # 全micropostのidが10超であることを検証
     response_json[:feed].each do |micropost|
-      assert_operator micropost[:id], :>, 1000000000
+      assert_operator micropost[:id], :>, 10
     end
+  end
+
+  test "feed取得(idが10以前のmicropostのみ)" do
+    # since_idを指定
+    get api_feed_path, {request_microposts: {max_id: 10}}, @headers
+    assert_response :success
+
+    # 全micropostのidが10以下であることを検証
+    response_json[:feed].each do |micropost|
+      assert_operator micropost[:id], :<=, 10
+    end
+  end
+
+  test "feed取得(idが20以前かつ10より後のmicropostのみを5件取得)" do
+    # since_idを指定
+    get api_feed_path, {request_microposts: {count: 5, since_id: 10, max_id: 20}}, @headers
+    assert_response :success
+
+    # 全micropostのidが20以下10超であることを検証
+    response_json[:feed].each do |micropost|
+      assert_operator micropost[:id], :<=, 20
+      assert_operator micropost[:id], :>, 10
+    end
+
+    # 5件取得する
+    assert_equal 5, response_json[:feed].length
   end
 end
 

--- a/test/integration/api/feed_test.rb
+++ b/test/integration/api/feed_test.rb
@@ -8,19 +8,50 @@ class Api::FeedTest< ActionDispatch::IntegrationTest
     @headers = {"Authorization" => "Bearer #{token}"}
   end
 
-  test "feed取得" do
+  test "feed取得(デフォルト)" do
     get api_feed_path, {}, @headers
     assert_response :success
 
-    params = response_json
-    assert_not_nil params[:feed]
-    assert_kind_of Array, params[:feed]
+    assert_not_nil response_json[:feed]
+    assert_kind_of Array, response_json[:feed]
 
     # feed配列の中身に値漏れがないかチェック
-    params[:feed].each do |micropost|
+    response_json[:feed].each do |micropost|
       %i(content user_id created_at updated_at picture).each do |element|
         assert_not_nil micropost[element]
       end
+    end
+
+    # パラメータ無しのため、30件取得する
+    assert_equal 30, response_json[:feed].length
+  end
+
+  test "feed取得(最新35件)" do
+    get api_feed_path, {request_microposts: {count: 35}}, @headers
+    assert_response :success
+
+    # 35件取得する
+    assert_equal 35, response_json[:feed].length
+  end
+
+  test "feed取得(最新10件)" do
+    get api_feed_path, {request_microposts: {count: 10}}, @headers
+    assert_response :success
+
+    # 10件取得する
+    assert_equal 10, response_json[:feed].length
+  end
+
+  test "feed取得(idが)" do
+    get api_feed_path, {request_microposts: {count: 35}}, @headers
+    assert_response :success
+
+    # 50件取得する
+    assert_equal 35, response_json[:feed].length
+
+    # 全micropostのidが100超であることを検証
+    response_json[:feed].each do |micropost|
+      assert_operator micropost[:id], :>, 1000000000
     end
   end
 end

--- a/test/integration/api/user_microposts_test.rb
+++ b/test/integration/api/user_microposts_test.rb
@@ -32,4 +32,47 @@ class Api::UserMicropostsTest< ActionDispatch::IntegrationTest
     get api_user_microposts_path(@non_active_user), {}, @headers
     assert_response :forbidden
   end
+
+  test "userのmicrpost取得(最新10件)" do
+    get api_user_microposts_path(@user), {request_microposts: {count: 10}}, @headers
+    assert_response :success
+
+    # 35件取得する
+    assert_equal 10, response_json[:microposts].length
+  end
+
+  test "userのmicrpost取得(idが10より後のみ)" do
+    get api_user_microposts_path(@user), {request_microposts: {since_id: 10}}, @headers
+    assert_response :success
+
+    # 全micropostのidが10超であることを検証
+    response_json[:microposts].each do |micropost|
+      assert_operator micropost[:id], :>, 10
+    end
+  end
+
+  test "userのmicrpost取得(idが10以前のみ)" do
+    get api_user_microposts_path(@user), {request_microposts: {max_id: 10}}, @headers
+    assert_response :success
+
+    # 全micropostのidが10以下であることを検証
+    response_json[:microposts].each do |micropost|
+      assert_operator micropost[:id], :<=, 10
+    end
+  end
+
+  test "micropost取得(idが20以前かつ10より後のmicropostのみを5件取得)" do
+    # since_idを指定
+    get api_user_microposts_path(@user), {request_microposts: {count: 5, since_id: 10, max_id: 20}}, @headers
+    assert_response :success
+
+    # 全micropostのidが20以下10超であることを検証
+    response_json[:microposts].each do |micropost|
+      assert_operator micropost[:id], :<=, 20
+      assert_operator micropost[:id], :>, 10
+    end
+
+    # 5件取得する
+    assert_equal 5, response_json[:microposts].length
+  end
 end


### PR DESCRIPTION
#70, #68 でfeedとmicropostのAPIを作りましたが、

全件取得できるのは問題なのでページングできるようにします。

ただし、「最新から30件を1ページ目とする…31件目から60件目を2ページ…」といった定義をしてしまうと、
1ページ目を取得した後、2ページ目を取得する前に最新のポストがあったりした時、1ページ目にあったツイートが2ページ目にずれてくるため同じツイートを読み込んでしまったりして問題になります。

ということで、ページ番号ではなくTwitter API方式でmicropostのidで取得するmicropostの範囲を指定するようにします。
### パラメータ

`GET /api/users/:user_id/microposts`及び`GET /api/feed`のパラメータ
- `request_microposts[count]`(デフォルト: 30)(Optional)
  - `count`の件数だけmicropostを取得する
- `request_microposts[since_id]`(Optional)
  - `since_id`より後(より大きい)のmicropostのみ取得する
  - 指定しなかったら最古のmicropostより後から取得
- `request_microposts[max_id]`(Optional)
  - `max_id`以前(以下)のmicropostのみ取得する
  - 指定しなかったら最新のmicropost以前から取得
