### PR TITLE
メール内URLが展開された時のbaseとなるhost名をsecrets.ymlで管理する

### DIFF
--- a/config/environments/production.rb
+++ b/config/environments/production.rb
@@ -64,7 +64,7 @@ Rails.application.configure do
   # Set this to true and configure the email server for immediate delivery to raise delivery errors.
    config.action_mailer.raise_delivery_errors = true
    config.action_mailer.delivery_method = :smtp
-   host = 'young-oasis-99979.herokuapp.com'
+   host = Rails.application.secrets[:host_name]
    config.action_mailer.default_url_options = {host: host, protocol: 'https'}
 
    ActionMailer::Base.smtp_settings = {


### PR DESCRIPTION
アカウントアクティベーションやパスワードリセットではメールにURLを張ってそこにアクセスする形になっています。

現在の設定(config/environments/production.rb)では

```
host = 'young-oasis-99979.herokuapp.com'
config.action_mailer.default_url_options = {host: host, protocol: 'https'}
```

となっているため、アカウントアクティベーションやパスワードリセットは全て`young-oasis-99979.herokuapp.com`に飛ばされてしまっています。

そこで、ホスト名をsecrets.yml(このファイルはインフラ側で管理している)で管理し、チームごとに適切なhost名に変更します
