### PR TITLE
ホスト名の変更

### DIFF
--- a/config/environments/production.rb
+++ b/config/environments/production.rb
@@ -64,7 +64,7 @@ Rails.application.configure do
   # Set this to true and configure the email server for immediate delivery to raise delivery errors.
    config.action_mailer.raise_delivery_errors = true
    config.action_mailer.delivery_method = :smtp
-   host = 'young-oasis-99979.herokuapp.com'
+   host = 'currry.xyz'
    config.action_mailer.default_url_options = {host: host, protocol: 'https'}
 
    ActionMailer::Base.smtp_settings = {


### PR DESCRIPTION
https://github.com/ogidow/railstutorial/pull/78
の方でホスト名直打ちという方針になったのでここで対応します
