### PR TITLE
他人のメールアドレスは見れないようにする

### DIFF
--- a/app/controllers/api/users_controller.rb
+++ b/app/controllers/api/users_controller.rb
@@ -85,7 +85,7 @@ class Api::UsersController < Api::ApplicationController
 
   def me
     @user = current_user
-    render 'show', status: :ok
+    render 'me', status: :ok
   end
 
   private

--- a/app/controllers/api/users_controller.rb
+++ b/app/controllers/api/users_controller.rb
@@ -32,8 +32,7 @@ class Api::UsersController < Api::ApplicationController
   def update
     @user = User.find(params[:id])
     if @user.update_attributes(user_params)
-      # メールアドレスも返すようにする
-      render 'me', status: :ok
+      render status: :ok
     else
       render nothing: true, status: :unprocessable_entity
     end

--- a/app/controllers/api/users_controller.rb
+++ b/app/controllers/api/users_controller.rb
@@ -32,7 +32,8 @@ class Api::UsersController < Api::ApplicationController
   def update
     @user = User.find(params[:id])
     if @user.update_attributes(user_params)
-      render status: :ok
+      # メールアドレスも返すようにする
+      render 'me', status: :ok
     else
       render nothing: true, status: :unprocessable_entity
     end

--- a/app/controllers/api/users_controller.rb
+++ b/app/controllers/api/users_controller.rb
@@ -86,7 +86,7 @@ class Api::UsersController < Api::ApplicationController
 
   def me
     @user = current_user
-    render 'me', status: :ok
+    render status: :ok
   end
 
   private

--- a/app/views/api/users/_user.json.jbuilder
+++ b/app/views/api/users/_user.json.jbuilder
@@ -1,2 +1,2 @@
-json.extract! user, :id, :name, :email, :activated
+json.extract! user, :id, :name, :activated
 json.icon_url gravatar_for(user, url: true)

--- a/app/views/api/users/_user_with_email.json.jbuilder
+++ b/app/views/api/users/_user_with_email.json.jbuilder
@@ -1,4 +1,4 @@
-json.extract! user, :id, :name, :activated
+json.extract! user, :id, :name, :email, :activated
 json.icon_url gravatar_for(user, url: true)
 json.following_count user.following.count
 json.followers_count user.followers.count

--- a/app/views/api/users/_user_with_email.json.jbuilder
+++ b/app/views/api/users/_user_with_email.json.jbuilder
@@ -1,5 +1,2 @@
-json.extract! user, :id, :name, :email, :activated
-json.icon_url gravatar_for(user, url: true)
-json.following_count user.following.count
-json.followers_count user.followers.count
-json.microposts_count user.microposts.count
+json.partial! "user", user: user
+json.email user.email

--- a/app/views/api/users/create.json.jbuilder
+++ b/app/views/api/users/create.json.jbuilder
@@ -1,7 +1,4 @@
 json.message "Created"
 json.user do
-  json.id @user.id
-  json.name @user.name
-  json.activated @user.activated
-  json.icon_url gravatar_for(@user, url: true)
+  json.partial! "user_with_email", user: @user
 end

--- a/app/views/api/users/followers.json.jbuilder
+++ b/app/views/api/users/followers.json.jbuilder
@@ -1,6 +1,8 @@
 json.followers do
   json.count @user.followers.count
   json.users do
-    json.array! @users, :id, :name, :email
+    json.array!(@users) do |user|
+      json.partial! "user", user: user
+    end
   end
 end

--- a/app/views/api/users/following.json.jbuilder
+++ b/app/views/api/users/following.json.jbuilder
@@ -1,6 +1,8 @@
 json.following do
   json.count @user.following.count
   json.users do
-    json.array! @users, :id, :name, :email
+    json.array!(@users) do |user|
+      json.partial! "user", user: user
+    end
   end
 end

--- a/app/views/api/users/index.json.jbuilder
+++ b/app/views/api/users/index.json.jbuilder
@@ -1,3 +1,5 @@
 json.users do
-  json.array! @users, :id, :name, :email
+  json.array!(@users) do |user|
+    json.partial! "user", user: user
+  end
 end

--- a/app/views/api/users/me.json.jbuilder
+++ b/app/views/api/users/me.json.jbuilder
@@ -1,5 +1,6 @@
 json.user do
   json.partial! "user", user: @user
+  json.email @user.email
   json.following_count @user.following.count
   json.followers_count @user.followers.count
   json.microposts_count @user.microposts.count

--- a/app/views/api/users/me.json.jbuilder
+++ b/app/views/api/users/me.json.jbuilder
@@ -1,7 +1,3 @@
 json.user do
-  json.partial! "user", user: @user
-  json.email @user.email
-  json.following_count @user.following.count
-  json.followers_count @user.followers.count
-  json.microposts_count @user.microposts.count
+  json.partial! "user_with_email", user: @user
 end

--- a/app/views/api/users/me.json.jbuilder
+++ b/app/views/api/users/me.json.jbuilder
@@ -1,0 +1,6 @@
+json.user do
+  json.partial! "user", user: @user
+  json.following_count @user.following.count
+  json.followers_count @user.followers.count
+  json.microposts_count @user.microposts.count
+end

--- a/app/views/api/users/show.json.jbuilder
+++ b/app/views/api/users/show.json.jbuilder
@@ -1,6 +1,3 @@
 json.user do
   json.partial! "user", user: @user
-  json.following_count @user.following.count
-  json.followers_count @user.followers.count
-  json.microposts_count @user.microposts.count
 end

--- a/app/views/api/users/update.json.jbuilder
+++ b/app/views/api/users/update.json.jbuilder
@@ -1,3 +1,3 @@
 json.user do
-  json.partial! "user", user: @user
+  json.partial! "user_with_email", user: @user
 end

--- a/test/integration/api/following_test.rb
+++ b/test/integration/api/following_test.rb
@@ -59,7 +59,8 @@ class Api::FollowingTest < ActionDispatch::IntegrationTest
     following = response_json[:following]
     assert_equal following[:count], @user.following.count
     following[:users].each do |user|
-      %i(id name email).each do |element|
+      assert_nil user[:email]
+      %i(id name).each do |element|
         assert_not_nil user[element]
       end
     end
@@ -72,7 +73,8 @@ class Api::FollowingTest < ActionDispatch::IntegrationTest
     followers = response_json[:followers]
     assert_equal followers[:count], @user.followers.count
     followers[:users].each do |user|
-      %i(id name email).each do |element|
+      assert_nil user[:email]
+      %i(id name).each do |element|
         assert_not_nil user[element]
       end
     end

--- a/test/integration/api/users_show_test.rb
+++ b/test/integration/api/users_show_test.rb
@@ -5,7 +5,7 @@ class Api::UsersShowTest < ActionDispatch::IntegrationTest
     @user = users(:michael)
     @active_user = users(:archer)
     @non_active_user = users(:ogido)
-    
+
     token = @user.generate_jwt
     @headers = {"Authorization" => "Bearer #{token}"}
   end
@@ -16,7 +16,8 @@ class Api::UsersShowTest < ActionDispatch::IntegrationTest
 
     assert_not_nil response_json[:user]
     assert_equal @active_user[:name], response_json[:user][:name]
-    assert_equal @active_user[:email], response_json[:user][:email]
+    # 他人のメールアドレスを見れないようにするため、showではメールアドレスを返さない
+    assert_nil response_json[:user][:email]
 
     assert_equal @active_user.following.count, response_json[:user][:following_count]
     assert_equal @active_user.followers.count, response_json[:user][:followers_count]


### PR DESCRIPTION
現状users#showではemailも返しているので、他人のメールアドレスを見れるようになってしまっている
users#meでのみemailを返して、users#showではemailを返さないようにしたい

→createとupdateでも返したいので、emailありのパーシャルを作って対応しました。
