### PR TITLE
microposts#showと、feedとでJSONのフォーマットが違うのを直す

### DIFF
--- a/app/views/api/lists/feed.json.jbuilder
+++ b/app/views/api/lists/feed.json.jbuilder
@@ -1,3 +1,5 @@
 json.feed do
-  json.array! @feed
+  json.array!(@feed) do |micropost|
+    json.partial! "api/microposts/micropost", micropost: micropost
+  end
 end

--- a/app/views/api/microposts/_micropost.json.jbuilder
+++ b/app/views/api/microposts/_micropost.json.jbuilder
@@ -1,1 +1,2 @@
-json.extract! micropost, :id, :content, :user_id, :created_at, :picture
+json.extract! micropost, :id, :content, :user_id, :created_at
+json.picture micropost.picture.url

--- a/app/views/api/microposts/_micropost.json.jbuilder
+++ b/app/views/api/microposts/_micropost.json.jbuilder
@@ -1,0 +1,1 @@
+json.extract! micropost, :id, :content, :user_id, :created_at, :picture

--- a/app/views/api/microposts/create.json.jbuilder
+++ b/app/views/api/microposts/create.json.jbuilder
@@ -1,3 +1,4 @@
+json.message "Created"
 json.micropost do
-  json.extract! @micropost, :id, :content, :picture, :created_at
+  json.partial! "micropost", micropost: @micropost
 end

--- a/app/views/api/microposts/show.json.jbuilder
+++ b/app/views/api/microposts/show.json.jbuilder
@@ -1,3 +1,3 @@
 json.micropost do
-  json.merge! @micropost.attributes
+  json.partial! "micropost", micropost: @micropost
 end

--- a/app/views/api/users/feed.json.jbuilder
+++ b/app/views/api/users/feed.json.jbuilder
@@ -1,3 +1,5 @@
 json.feed do
-  json.array! @feed
+  json.array!(@feed) do |micropost|
+    json.partial! "api/microposts/micropost", micropost: micropost
+  end
 end

--- a/app/views/api/users/microposts.json.jbuilder
+++ b/app/views/api/users/microposts.json.jbuilder
@@ -1,3 +1,5 @@
 json.microposts do
-  json.array! @microposts
+  json.array!(@microposts) do |micropost|
+    json.partial! "api/microposts/micropost", micropost: micropost
+  end
 end

--- a/config/initializers/carrier_wave.rb
+++ b/config/initializers/carrier_wave.rb
@@ -1,5 +1,5 @@
-if Rails.env.production?
-  CarrierWave.configure do |config|
+CarrierWave.configure do |config|
+  if Rails.env.production?
     config.aws_credentials = {
       access_key_id: ENV['BAYT_KEY'],
       secret_access_key: ENV['BAYT_SECRET'],
@@ -10,5 +10,8 @@ if Rails.env.production?
     config.asset_host = ENV['BAYT_ASSET_URL']
     config.aws_bucket = 'sandbox'
     config.aws_acl = 'public-read'
+  else
+    # production以外でもURLにホスト名が含まれるようにしておく(APIのJSONレスポンスで必要)
+    config.asset_host = 'http://localhost:3000'
   end
 end

--- a/test/integration/api/feed_test.rb
+++ b/test/integration/api/feed_test.rb
@@ -3,7 +3,7 @@ require 'test_helper'
 class Api::FeedTest< ActionDispatch::IntegrationTest
   def setup
     @user = users(:michael)
-    
+
     token = @user.generate_jwt
     @headers = {"Authorization" => "Bearer #{token}"}
   end
@@ -17,7 +17,7 @@ class Api::FeedTest< ActionDispatch::IntegrationTest
 
     # feed配列の中身に値漏れがないかチェック
     response_json[:feed].each do |micropost|
-      %i(content user_id created_at updated_at picture).each do |element|
+      %i(content user_id created_at).each do |element|
         assert_not_nil micropost[element]
       end
     end

--- a/test/integration/api/lists_feed_test.rb
+++ b/test/integration/api/lists_feed_test.rb
@@ -18,13 +18,13 @@ class Api::ListsFeedTest < ActionDispatch::IntegrationTest
     assert_kind_of Array, response_json[:feed]
 
     response_json[:feed].each do |micropost|
-      %i(content user_id created_at updated_at picture).each do |element|
+      %i(content user_id created_at).each do |element|
         assert_not_nil micropost[element]
       end
     end
     assert_equal 30, response_json[:feed].count
   end
-	
+
   test "feed取得(最新35件)" do
     get feed_api_list_path(@list), {request_microposts: {count: 35}}, @headers
     assert_response :success

--- a/test/integration/api/microposts_post_test.rb
+++ b/test/integration/api/microposts_post_test.rb
@@ -19,8 +19,9 @@ class Api::MicropostsPostTest < ActionDispatch::IntegrationTest
     assert_response :created
     assert assigns(:micropost).picture?
 
-    params = response_json
-    assert_equal params[:micropost][:content], content
+    micropost = response_json[:micropost]
+    assert_equal micropost[:content], content
+    assert_not_empty micropost[:picture]
   end
 
   test "空のマイクロポストの投稿(認証あり)" do

--- a/test/integration/api/microposts_show_test.rb
+++ b/test/integration/api/microposts_show_test.rb
@@ -23,6 +23,5 @@ class Api::MicropostsShowTest < ActionDispatch::IntegrationTest
     assert_equal @micropost[:picture], response_micropost[:picture]
     # 時間の形式がDBと出力jsonで違うので合わせる
     assert_equal @micropost.created_at.xmlschema(3), response_micropost[:created_at]
-    assert_equal @micropost.updated_at.xmlschema(3), response_micropost[:updated_at]
   end
 end

--- a/test/integration/api/microposts_show_test.rb
+++ b/test/integration/api/microposts_show_test.rb
@@ -20,7 +20,7 @@ class Api::MicropostsShowTest < ActionDispatch::IntegrationTest
     assert_equal @micropost.id,        response_micropost[:id]
     assert_equal @micropost.content,   response_micropost[:content]
     assert_equal @micropost.user_id,   response_micropost[:user_id]
-    assert_equal @micropost[:picture], response_micropost[:picture]
+    assert_equal @micropost.picture.url, response_micropost[:picture]
     # 時間の形式がDBと出力jsonで違うので合わせる
     assert_equal @micropost.created_at.xmlschema(3), response_micropost[:created_at]
   end

--- a/test/integration/api/user_microposts_test.rb
+++ b/test/integration/api/user_microposts_test.rb
@@ -5,7 +5,7 @@ class Api::UserMicropostsTest< ActionDispatch::IntegrationTest
     @user = users(:michael)
     @active_user = users(:archer)
     @non_active_user = users(:ogido)
-    
+
     token = @user.generate_jwt
     @headers = {"Authorization" => "Bearer #{token}"}
   end
@@ -20,7 +20,7 @@ class Api::UserMicropostsTest< ActionDispatch::IntegrationTest
 
     # microposts配列の中身に値漏れがないかチェック
     params[:microposts].each do |micropost|
-      %i(content user_id created_at updated_at picture).each do |element|
+      %i(content user_id created_at).each do |element|
         assert_not_nil micropost[element]
       end
 


### PR DESCRIPTION
microposts#showと、feedとでJSONのフォーマットが違う問題が発生
パーシャルで共通化することで修正します
- pictureキーに画像URLが入るように統一しました
- micropostは更新できないのでupdated_atを返す必要はなく、削除しました
- CarrierWaveの.urlはデフォルトではホスト名部分を含まないため、本番環境以外でもasset_hostを設定して統一
  - もともと本番環境ではBayt使うためasset_hostが設定されていた＝本番環境ではフルURLになってくれる

```
{
  "micropost": {
    "id": 39,
    "content": "this is picture",
    "user_id": 762146111,
    "created_at": "2016-10-05T03:07:30.196Z",
    "picture": "http://localhost:3000/uploads/micropost/picture/39/rails.png"
  }
}
```
