### PR TITLE
nothing: trueで何も返していないところを空のjsonを返すようにする

### DIFF
--- a/app/controllers/api/lists/members_controller.rb
+++ b/app/controllers/api/lists/members_controller.rb
@@ -9,7 +9,7 @@ class Api::Lists::MembersController < Api::ApplicationController
   def create
     list = List.find_by(id: params[:list_id])
     @user = User.find_by(id: params[:user_id])
-    render nothing: true, status: :unprocessable_entity and return if list.nil? || @user.nil?
+    render json: "{}", status: :unprocessable_entity and return if list.nil? || @user.nil?
     member = list.list_members.build(user_id: @user.id)
 
     if member.save
@@ -25,18 +25,18 @@ class Api::Lists::MembersController < Api::ApplicationController
 
   def destroy
     list = List.find_by(id: params[:list_id])
-    render nothing: true, status: :unprocessable_entity and return if list.nil?
+    render json: "{}", status: :unprocessable_entity and return if list.nil?
     list_member = list.list_members.find_by(user_id: params[:id])
-    render nothing: true, status: :unprocessable_entity and return if list_member.nil?
+    render json: "{}", status: :unprocessable_entity and return if list_member.nil?
 
     list_member.destroy
-    render nothing: true, status: :ok
+    render json: "{}", status: :ok
   end
   
   private
   def correct_user
     list = List.find_by(id: params[:list_id])
-    render nothing: true, status: :forbidden and return unless current_user.lists.include?(list)
+    render json: "{}", status: :forbidden and return unless current_user.lists.include?(list)
   end
 
 end

--- a/app/controllers/api/lists_controller.rb
+++ b/app/controllers/api/lists_controller.rb
@@ -24,14 +24,14 @@ class Api::ListsController < Api::ApplicationController
     if @list.update_attributes(list_params)
       render status: :ok
     else
-      render nothing: true, status: :unprocessable_entity
+      render json: "{}", status: :unprocessable_entity
     end
   end
 
   def destroy
     list = List.find(params[:id])
     list.destroy
-    render nothing: true, status: :ok
+    render json: "{}", status: :ok
   end
 
   def feed
@@ -49,7 +49,7 @@ class Api::ListsController < Api::ApplicationController
 
   def correct_user
     list = current_user.lists.find_by(id: params[:id])
-    render nothing: true, status: :forbidden and return if list.nil?
+    render json: "{}", status: :forbidden and return if list.nil?
   end
 
   def request_microposts_params

--- a/app/controllers/api/microposts_controller.rb
+++ b/app/controllers/api/microposts_controller.rb
@@ -22,7 +22,7 @@ class Api::MicropostsController < Api::ApplicationController
   def destroy
     micropost = Micropost.find_by(id: params[:id])
     micropost.destroy
-    render nothing: true, status: :ok
+    render json: "{}", status: :ok
   end
 
   private
@@ -32,6 +32,6 @@ class Api::MicropostsController < Api::ApplicationController
 
     def correct_user
       micropost = current_user.microposts.find_by(id: params[:id])
-      render nothing: true, status: :forbidden and return if micropost.nil?
+      render json: "{}", status: :forbidden and return if micropost.nil?
     end
 end

--- a/app/controllers/api/relationships_controller.rb
+++ b/app/controllers/api/relationships_controller.rb
@@ -3,11 +3,11 @@ class Api::RelationshipsController < Api::ApplicationController
 
   def create
     @user = User.find_by(id: relationship_params[:followed_id])
-    render nothing: true, status: :unprocessable_entity and return if @user.nil?
+    render json: "{}", status: :unprocessable_entity and return if @user.nil?
 
     @follow = current_user.follow(@user)
     if @follow.persisted?
-      render nothing: true, status: :created
+      render json: "{}", status: :created
     else
       build_json = Jbuilder.encode do |json|
         json.message "Validation Failed"
@@ -19,10 +19,10 @@ class Api::RelationshipsController < Api::ApplicationController
 
   def destroy
     @relation = Relationship.find_by(id: params[:id])
-    render nothing: true, status: :unprocessable_entity and return if @relation.nil?
+    render json: "{}", status: :unprocessable_entity and return if @relation.nil?
 
     current_user.unfollow(@relation.followed)
-    render nothing: true, status: :ok
+    render json: "{}", status: :ok
   end
 
   private

--- a/app/controllers/api/users_controller.rb
+++ b/app/controllers/api/users_controller.rb
@@ -11,7 +11,7 @@ class Api::UsersController < Api::ApplicationController
   def show
     @user = User.find(params[:id])
 
-    render nothing: true, status: :forbidden unless @user.activated?
+    render json: "{}", status: :forbidden unless @user.activated?
   end
 
   def create
@@ -34,16 +34,16 @@ class Api::UsersController < Api::ApplicationController
     if @user.update_attributes(user_params)
       render status: :ok
     else
-      render nothing: true, status: :unprocessable_entity
+      render json: "{}", status: :unprocessable_entity
     end
   end
 
   def destroy
     user = User.find_by(id: params[:id])
-    render nothing: true, status: :not_found and return if user.nil?
+    render json: "{}", status: :not_found and return if user.nil?
 
     user.destroy
-    render nothing: true, status: :ok
+    render json: "{}", status: :ok
   end
 
   def following
@@ -61,7 +61,7 @@ class Api::UsersController < Api::ApplicationController
   def microposts
     @user = User.find(params[:user_id])
 
-    render nothing: true, status: :forbidden and return unless @user.activated?
+    render json: "{}", status: :forbidden and return unless @user.activated?
 
     @microposts = @user.microposts.restrict(request_microposts_params.to_h.symbolize_keys)
 
@@ -70,7 +70,7 @@ class Api::UsersController < Api::ApplicationController
 
   def feed
     @user = current_user
-    render nothing: true, status: :forbidden and return unless @user.activated?
+    render json: "{}", status: :forbidden and return unless @user.activated?
     @feed = @user.feed.restrict(request_microposts_params.to_h.symbolize_keys)
 
     render 'feed', status: :ok
@@ -78,7 +78,7 @@ class Api::UsersController < Api::ApplicationController
 
   def lists
     @user = current_user
-    render nothing: true, status: :forbidden and return unless @user.activated?
+    render json: "{}", status: :forbidden and return unless @user.activated?
     @lists = @user.lists.paginate(page: params[:page])
     render status: :ok
   end
@@ -99,6 +99,6 @@ class Api::UsersController < Api::ApplicationController
 
     def correct_user
       user = User.find(params[:id])
-      render nothing: true, status: :forbidden and return unless user == current_user
+      render json: "{}", status: :forbidden and return unless user == current_user
     end
 end


### PR DESCRIPTION
APIクライアントで使用しているAlamofireがレスポンスにデータを含めないとエラーを吐いてしまうので空のjsonを返すようにします

参考
http://cocoadocs.org/docsets/Alamofire/4.0.1/Enums/AFError/ResponseSerializationFailureReason.html#/s:FOO9Alamofire7AFError34ResponseSerializationFailureReason24inputDataNilOrZeroLengthFMS1_S1_
