### PR TITLE
フォロー フォロワー一覧取得時のページネイトを外す

### DIFF
--- a/app/controllers/api/users_controller.rb
+++ b/app/controllers/api/users_controller.rb
@@ -48,13 +48,13 @@ class Api::UsersController < Api::ApplicationController
 
   def following
     @user = User.find(params[:user_id])
-    @users = @user.following.paginate(page: params[:page])
+    @users = @user.following
     render 'following', status: :ok
   end
 
   def followers
     @user = User.find(params[:user_id])
-    @users = @user.followers.paginate(page: params[:page])
+    @users = @user.followers
     render 'followers', status: :ok
   end
 


### PR DESCRIPTION
ページネイトをすることでクライアント側のロジックが複雑になるのと、ページネイトをしなくてもデータ量的にも問題ないだろうということで外します
