### PR TITLE
APIでのRelationshipの削除をuser_id指定でできるようにする

### DIFF
--- a/app/controllers/api/relationships_controller.rb
+++ b/app/controllers/api/relationships_controller.rb
@@ -25,6 +25,14 @@ class Api::RelationshipsController < Api::ApplicationController
     render json: "{}", status: :ok
   end
 
+  def destroy_by_userid
+    @relation = Relationship.find_by(followed_id: relationship_params[:followed_id])
+    render json: "{}", status: :unprocessable_entity and return if @relation.nil?
+
+    current_user.unfollow(@relation.followed)
+    render json: "{}", status: :ok
+  end
+
   private
     def relationship_params
       params.require(:relationship).permit(:followed_id)

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -39,6 +39,8 @@ Rails.application.routes.draw do
     resources :microposts, only: [:create, :destroy, :show]
     get 'feed' => 'users#feed'
     resources :relationships, only: [:create, :destroy]
+    delete 'relationship' => 'relationship#destroy_by_userid'
+
     get 'lists' => 'users#lists'
 
     resources :lists, only: [:create, :destroy, :update, :show] do

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -39,7 +39,7 @@ Rails.application.routes.draw do
     resources :microposts, only: [:create, :destroy, :show]
     get 'feed' => 'users#feed'
     resources :relationships, only: [:create, :destroy]
-    delete 'relationship' => 'relationship#destroy_by_userid'
+    delete 'relationship' => 'relationships#destroy_by_userid'
 
     get 'lists' => 'users#lists'
 

--- a/test/controllers/api/relationships_controller_test.rb
+++ b/test/controllers/api/relationships_controller_test.rb
@@ -14,4 +14,11 @@ class Api::RelationshipsControllerTest < ActionController::TestCase
     end
     assert_response :unauthorized
   end
+
+  test "Relationshipの削除には認証が必要(userId)" do
+    assert_no_difference 'Relationship.count' do
+      delete :destroy_by_userid, format: :json, relationship: { followed_id: users(:archer).id}
+    end
+    assert_response :unauthorized
+  end
 end

--- a/test/integration/api/following_test.rb
+++ b/test/integration/api/following_test.rb
@@ -41,6 +41,15 @@ class Api::FollowingTest < ActionDispatch::IntegrationTest
     assert_response :ok
   end
 
+  test "ユーザidでアンフォロー" do
+    @user.follow(@other)
+
+    assert_difference '@user.following.count', -1 do
+      delete '/api/relationship', {relationship: {followed_id: @other.id}}, @headers
+    end
+    assert_response :ok
+  end
+
   test "アンフォローできなければエラーを返すこと" do
     @user.follow(@other)
     relationship = @user.active_relationships.find_by(followed_id: @other.id)


### PR DESCRIPTION
本来Relationshipの削除は`DELETE /api/relationships/:id`というようにrelationshipのidを指定することで行います。

しかし現在のAPIではidを取得する方法がありません。
(ちなみにWeb版ではサーバ側がidを探してViewのフォームに埋め込むというアレになっています)

作成時(`POST /api/relationships/`)のレスポンスやshowメソッドを追加するなどして、relationshipのidを返すことも可能ですが、クライアントはrelationshipのidを取得した上でそれを削除するまで覚えておく必要があります。
非常に利便性が悪いので、relationship作成時と同様に`followed_id`(ユーザのid)をパラメータとしてリクエストを投げることで削除も可能とするようなAPIを追加します。

メソッド・エンドポイントは`DELETE /api/relationship`です
