### PR TITLE
マイクロポストのレスポンスにユーザー情報を含める

### DIFF
--- a/app/views/api/microposts/_micropost.json.jbuilder
+++ b/app/views/api/microposts/_micropost.json.jbuilder
@@ -1,2 +1,5 @@
 json.extract! micropost, :id, :content, :user_id, :created_at
 json.picture micropost.picture.url
+json.user do
+  json.partial! "api/users/user", user: micropost.user
+end

--- a/app/views/api/sessions/create.json.jbuilder
+++ b/app/views/api/sessions/create.json.jbuilder
@@ -1,8 +1,4 @@
-json.user do
-  json.id @user.id
-  json.name @user.name
-  json.email @user.email
-  json.icon_url gravatar_for(@user, url: true)
-end
-
 json.token @user.generate_jwt
+json.user do
+  json.partial! "api/users/user_with_email", user: @user
+end

--- a/app/views/api/users/_user_with_email.json.jbuilder
+++ b/app/views/api/users/_user_with_email.json.jbuilder
@@ -1,2 +1,2 @@
-json.partial! "user", user: user
+json.partial! "api/users/user", user: user
 json.email user.email

--- a/test/integration/api/feed_test.rb
+++ b/test/integration/api/feed_test.rb
@@ -17,7 +17,7 @@ class Api::FeedTest< ActionDispatch::IntegrationTest
 
     # feed配列の中身に値漏れがないかチェック
     response_json[:feed].each do |micropost|
-      %i(content user_id created_at).each do |element|
+      %i(content user_id created_at user).each do |element|
         assert_not_nil micropost[element]
       end
     end

--- a/test/integration/api/lists_feed_test.rb
+++ b/test/integration/api/lists_feed_test.rb
@@ -18,7 +18,7 @@ class Api::ListsFeedTest < ActionDispatch::IntegrationTest
     assert_kind_of Array, response_json[:feed]
 
     response_json[:feed].each do |micropost|
-      %i(content user_id created_at).each do |element|
+      %i(content user_id created_at user).each do |element|
         assert_not_nil micropost[element]
       end
     end

--- a/test/integration/api/microposts_show_test.rb
+++ b/test/integration/api/microposts_show_test.rb
@@ -23,5 +23,7 @@ class Api::MicropostsShowTest < ActionDispatch::IntegrationTest
     assert_equal @micropost.picture.url, response_micropost[:picture]
     # 時間の形式がDBと出力jsonで違うので合わせる
     assert_equal @micropost.created_at.xmlschema(3), response_micropost[:created_at]
+    # ユーザー情報が含まれているか
+    assert_equal @micropost.user.name, response_micropost[:user][:name]
   end
 end


### PR DESCRIPTION
現状はマイクロポストの情報だけ返してますが、特にフィードだといちいちユーザー情報を取りに行かないといけなくなり効率が悪くなります。
というわけでユーザー情報も一緒に返すようにします。

sessions#createにパーシャル漏れがあったのでついでに直しています
