### PR TITLE
どうしても絵文字を投稿したいのでutf8mb4にしてみる

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -15,8 +15,8 @@ before_script:
   - echo mysql-apt-config mysql-apt-config/select-server select mysql-5.7 | sudo debconf-set-selections
   - wget http://dev.mysql.com/get/mysql-apt-config_0.7.3-1_all.deb
   - sudo dpkg --install mysql-apt-config_0.7.3-1_all.deb
-  - sudo apt-get update -q
-  - sudo apt-get install -q -y -o Dpkg::Options::=--force-confnew mysql-server
+  - sudo apt-get update -qq
+  - sudo apt-get install -qq -o Dpkg::Options::=--force-confnew mysql-server
   - sudo mysql_upgrade
   - cp config/database.yml.travis config/database.yml
   - bin/rake db:setup

--- a/.travis.yml
+++ b/.travis.yml
@@ -13,8 +13,8 @@ cache: bundler
 before_script:
   # MySQL5.7をインストール
   - echo mysql-apt-config mysql-apt-config/select-server select mysql-5.7 | sudo debconf-set-selections
-  - wget http://dev.mysql.com/get/mysql-apt-config_0.7.3-1_all.deb
-  - sudo dpkg --install mysql-apt-config_0.7.3-1_all.deb
+  - wget https://dev.mysql.com/get/mysql-apt-config_0.8.0-1_all.deb
+  - sudo dpkg --install mysql-apt-config_0.8.0-1_all.deb
   - sudo apt-get update -qq
   - sudo apt-get install -qq -o Dpkg::Options::=--force-confnew mysql-server
   - sudo mysql_upgrade

--- a/.travis.yml
+++ b/.travis.yml
@@ -11,6 +11,13 @@ bundler_args: "--without development --deployment"
 cache: bundler
 
 before_script:
+  # MySQL5.7をインストール
+  - echo mysql-apt-config mysql-apt-config/select-server select mysql-5.7 | sudo debconf-set-selections
+  - wget http://dev.mysql.com/get/mysql-apt-config_0.7.3-1_all.deb
+  - sudo dpkg --install mysql-apt-config_0.7.3-1_all.deb
+  - sudo apt-get update -q
+  - sudo apt-get install -q -y -o Dpkg::Options::=--force-confnew mysql-server
+  - sudo mysql_upgrade
   - cp config/database.yml.travis config/database.yml
   - bin/rake db:setup
 

--- a/config/database.yml
+++ b/config/database.yml
@@ -22,7 +22,8 @@ test:
 
 production:
   adapter: mysql2
-  encoding: utf8
+  encoding: utf8mb4
+  collation: utf8mb4_bin
   pool: 5
   timeout: 5000
   username: <%= ENV["DATABASE_USERNAME"] %>

--- a/config/database.yml.travis
+++ b/config/database.yml.travis
@@ -1,5 +1,6 @@
 test:
   adapter: mysql2
-  encoding: utf8
+  encoding: utf8mb4
+  collation: utf8mb4_bin
   database: travis_ci_test
   username: travis


### PR DESCRIPTION
まずCI通るか確認してみる

TravisのMySQLは5.5.37らしい…
https://docs.travis-ci.com/user/database-setup/

できるだけ簡単に ActiveRecord で utf8mb4 を動かす - milk1000cc's blog
http://milk1000cc.hatenablog.com/entry/2016/03/22/172353

本番で使ってる5.7だと比較的楽できるらしい
MySQL 5.7 と絵文字（ちょこっと Rails） - TMD45'β'LOG!!!
http://blog.tmd45.jp/entry/2016/07/30/134145
